### PR TITLE
use "npm-bin-ava-tester" package to test CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "Simon Dobie",
   "license": "BSD-3-Clause",
   "devDependencies": {
-    "ava": "^0.15.2",
+    "ava": "^0.16.0",
     "eslint": "^2.11.1",
     "eslint-config-semistandard": "^6.0.2",
     "eslint-config-standard": "^5.3.1",
@@ -23,6 +23,7 @@
     "fixpack": "^2.3.1",
     "jsdoc": "^3.4.0",
     "mockery": "^1.4.1",
+    "npm-bin-ava-tester": "^1.0.0",
     "npm-run-all": "^2.2.2",
     "yauzl": "^2.6.0"
   },

--- a/test/cli.js
+++ b/test/cli.js
@@ -2,18 +2,13 @@
 
 const path = require('path');
 
-const fs = require('@jokeyrhyme/pify-fs');
+const npmBinTester = require('npm-bin-ava-tester');
 const test = require('ava');
 const execa = require('execa');
 
+npmBinTester(test);
+
 const CLI_PATH = path.join(__dirname, '..', 'bin', 'index.js');
-
-test('bin/index.js is executable', (t) => fs.access(CLI_PATH, fs.X_OK));
-
-test('bin/index.js has no CRLF', (t) => {
-  return fs.readFile(CLI_PATH, 'utf8')
-    .then((data) => t.is(data.indexOf('\r\n'), -1));
-});
 
 test('bin/index.js --help', (t) => {
   return execa('node', [ CLI_PATH, '--help' ])


### PR DESCRIPTION
### Changed
- ensure Node.js CLI conventions are followed with [npm-bin-ava-tester](https://github.com/jokeyrhyme/npm-bin-ava-tester.js)
