### PR TITLE
Revert "Update inquirer to version 1.3.0 🚀"

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "chalk": "1.1.3",
     "elegant-spinner": "1.0.1",
     "execa": "0.5.0",
-    "inquirer": "1.3.0",
+    "inquirer": "1.2.3",
     "lodash.memoize": "4.1.2",
     "log-update": "1.0.2",
     "meow": "3.7.0",


### PR DESCRIPTION
-   Reverts blinkmobile/buildbot-cli#37

-   [inquirer](https://www.npmjs.com/package/inquirer) never published [1.3.0](https://github.com/SBoudrias/Inquirer.js/releases/tag/v1.3.0) to npm:

    > Unpublished due to backward compatibility issue